### PR TITLE
Add the ability to set Content-ID header for ParamPart

### DIFF
--- a/lib/parts.rb
+++ b/lib/parts.rb
@@ -35,7 +35,7 @@ module Parts
     # @param boundary [String]
     # @param name [#to_s]
     # @param value [String]
-    # @param headers [Hash] Content-Type is used, if present.
+    # @param headers [Hash] Content-Type and Content-ID are used, if present.
     def initialize(boundary, name, value, headers = {})
       @part = build_part(boundary, name, value, headers)
       @io = StringIO.new(@part)

--- a/lib/parts.rb
+++ b/lib/parts.rb
@@ -52,6 +52,7 @@ module Parts
     def build_part(boundary, name, value, headers = {})
       part = ''
       part << "--#{boundary}\r\n"
+      part << "Content-ID: #{headers["Content-ID"]}\r\n" if headers["Content-ID"]
       part << "Content-Disposition: form-data; name=\"#{name.to_s}\"\r\n"
       part << "Content-Type: #{headers["Content-Type"]}\r\n" if headers["Content-Type"]
       part << "\r\n"

--- a/spec/parts_spec.rb
+++ b/spec/parts_spec.rb
@@ -99,4 +99,9 @@ RSpec.describe Parts::ParamPart do
   it "test_correct_length" do
     assert_part_length @part
   end
+
+  it "test_content_id" do
+    part = Parts::ParamPart.new("boundary", "with_content_id", "foobar", "Content-ID" => "id")
+    expect(part.to_io.read).to match(/Content-ID: id/)
+  end
 end


### PR DESCRIPTION
Hi 👋 

I added the ability to set the `Content-ID` header for `ParamPart` objects. Before, only the `Content-Type` could be set.