### PR TITLE
parts.rb: Use a mutable string

### DIFF
--- a/lib/multipart/post/parts.rb
+++ b/lib/multipart/post/parts.rb
@@ -93,7 +93,7 @@ module Multipart
           trans_encoding = opts.delete("Content-Transfer-Encoding") || "binary"
           content_disposition = opts.delete("Content-Disposition") || "form-data"
 
-          part = ''
+          part = +''
           part << "--#{boundary}\r\n"
           part << "Content-Disposition: #{content_disposition}; name=\"#{name.to_s}\"; filename=\"#{filename}\"\r\n"
           part << "Content-Length: #{content_len}\r\n"

--- a/lib/multipart/post/parts.rb
+++ b/lib/multipart/post/parts.rb
@@ -52,7 +52,7 @@ module Multipart
         # @param value [String]
         # @param headers [Hash] Content-Type is used, if present.
         def build_part(boundary, name, value, headers = {})
-          part = ''
+          part = String.new
           part << "--#{boundary}\r\n"
           part << "Content-ID: #{headers["Content-ID"]}\r\n" if headers["Content-ID"]
           part << "Content-Disposition: form-data; name=\"#{name.to_s}\"\r\n"
@@ -93,7 +93,7 @@ module Multipart
           trans_encoding = opts.delete("Content-Transfer-Encoding") || "binary"
           content_disposition = opts.delete("Content-Disposition") || "form-data"
 
-          part = +''
+          part = String.new
           part << "--#{boundary}\r\n"
           part << "Content-Disposition: #{content_disposition}; name=\"#{name.to_s}\"; filename=\"#{filename}\"\r\n"
           part << "Content-Length: #{content_len}\r\n"
@@ -122,7 +122,7 @@ module Multipart
         include Part
 
         def initialize(boundary)
-          @part = "--#{boundary}--\r\n"
+          @part = String.new("--#{boundary}--\r\n")
           @io = StringIO.new(@part)
         end
       end


### PR DESCRIPTION

## Description

Use an explicitly mutable string, to support `RUBYOPT=--enable-frozen-string-literal`

I ran into it when trying to get support for that in octokit.rb, and into github-changelog-generator.

https://github.com/octokit/octokit.rb/pull/1354/checks?check_run_id=3298433252

### Types of Changes

- Bug fix, perhaps maintenance

### Testing

Would it be OK to add the RUBYOPT setting mentioned above to CI? Oh, we don't have a running CI, I logged #71.
