### PR TITLE
Frozen string for entire library

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby-version: ['2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0']
+        ruby-version: ['2.6', '2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v2
@@ -26,3 +26,5 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake
+      env:
+        RUBYOPT: --enable-frozen-string-literal

--- a/lib/multipart/post/composite_read_io.rb
+++ b/lib/multipart/post/composite_read_io.rb
@@ -25,7 +25,7 @@ module Multipart
       # Read from IOs in order until `length` bytes have been received.
       def read(length = nil, outbuf = nil)
         got_result = false
-        outbuf = outbuf ? outbuf.replace("") : ""
+        outbuf = outbuf ? outbuf.replace("") : String.new
 
         while io = current_io
           if result = io.read(length)

--- a/spec/multipart/post/composite_read_io_spec.rb
+++ b/spec/multipart/post/composite_read_io_spec.rb
@@ -43,7 +43,7 @@ RSpec.shared_context "composite io" do
   end
   
   it "test_read_into_buffer" do
-    buf = ''
+    buf = String.new
     subject.read(nil, buf)
     expect(buf).to be == 'the quick brown fox'
   end


### PR DESCRIPTION
## Description

Working on the `String.new` has helped move things forward with a downstream consumer of this library.

When I enable frozen strings for the entire library, the tests fail.

### Types of Changes

- [x] Bug fix (for downstream consumers who do not expect mutation, or attempt to use frozen string literals with more functionality).
- [x] Breaking change.
- [x] Maintenance.

This currently removes Ruby `2.0`, `2.1`, `2.2`, `2.3` and `2.4` (early 2013-late 2016)

[Edit] At the request of @ioquatix this now also removes Ruby 2.5 to keep CI simple. For anyone interested in 2.5 see [commit](https://github.com/olleolleolle/octokit.rb/commit/722ec552d82a97ea98b3706b4e7c217aece8d156) and more specifically [orphaned commit from fork of this repo](https://github.com/Lewiscowles1986/multipart-post/blob/1c582daf2a64e76c19a4a37ce10a8b7e7b498668/.github/workflows/ruby.yml)

### Testing

<details>
<summary>Failing test summary</summary>

```
Finished in 0.01378 seconds (files took 0.1659 seconds to load)
51 examples, 32 failures

Failed examples:

rspec ./spec/multipart/post/composite_read_io_spec.rb:131 # Multipart::Post::CompositeReadIO test_empty_parts
rspec './spec/multipart/post/composite_read_io_spec.rb[1:1:5]' # Multipart::Post::CompositeReadIO generic io test_read_into_buffer
rspec './spec/multipart/post/composite_read_io_spec.rb[1:2:1]' # Multipart::Post::CompositeReadIO composite io test_full_read_from_several_ios
rspec './spec/multipart/post/composite_read_io_spec.rb[1:2:2]' # Multipart::Post::CompositeReadIO composite io test_partial_read
rspec './spec/multipart/post/composite_read_io_spec.rb[1:2:3]' # Multipart::Post::CompositeReadIO composite io test_partial_read_to_boundary
rspec './spec/multipart/post/composite_read_io_spec.rb[1:2:4]' # Multipart::Post::CompositeReadIO composite io test_read_with_size_larger_than_available
rspec './spec/multipart/post/composite_read_io_spec.rb[1:2:5]' # Multipart::Post::CompositeReadIO composite io test_read_into_buffer
rspec './spec/multipart/post/composite_read_io_spec.rb[1:2:6]' # Multipart::Post::CompositeReadIO composite io test_multiple_reads
rspec './spec/multipart/post/composite_read_io_spec.rb[1:2:7]' # Multipart::Post::CompositeReadIO composite io test_read_after_end
rspec './spec/multipart/post/composite_read_io_spec.rb[1:2:8]' # Multipart::Post::CompositeReadIO composite io test_read_after_end_with_amount
rspec './spec/multipart/post/composite_read_io_spec.rb[1:2:9]' # Multipart::Post::CompositeReadIO composite io test_second_full_read_after_rewinding
rspec './spec/multipart/post/composite_read_io_spec.rb[1:3:1]' # Multipart::Post::CompositeReadIO nested composite io test_full_read_from_several_ios
rspec './spec/multipart/post/composite_read_io_spec.rb[1:3:2]' # Multipart::Post::CompositeReadIO nested composite io test_partial_read
rspec './spec/multipart/post/composite_read_io_spec.rb[1:3:3]' # Multipart::Post::CompositeReadIO nested composite io test_partial_read_to_boundary
rspec './spec/multipart/post/composite_read_io_spec.rb[1:3:4]' # Multipart::Post::CompositeReadIO nested composite io test_read_with_size_larger_than_available
rspec './spec/multipart/post/composite_read_io_spec.rb[1:3:5]' # Multipart::Post::CompositeReadIO nested composite io test_read_into_buffer
rspec './spec/multipart/post/composite_read_io_spec.rb[1:3:6]' # Multipart::Post::CompositeReadIO nested composite io test_multiple_reads
rspec './spec/multipart/post/composite_read_io_spec.rb[1:3:7]' # Multipart::Post::CompositeReadIO nested composite io test_read_after_end
rspec './spec/multipart/post/composite_read_io_spec.rb[1:3:8]' # Multipart::Post::CompositeReadIO nested composite io test_read_after_end_with_amount
rspec './spec/multipart/post/composite_read_io_spec.rb[1:3:9]' # Multipart::Post::CompositeReadIO nested composite io test_second_full_read_after_rewinding
rspec './spec/multipart/post/composite_read_io_spec.rb[1:3:10]' # Multipart::Post::CompositeReadIO nested composite io test_compatible_with_copy_stream
rspec ./spec/multipart/post/composite_read_io_spec.rb:112 # Multipart::Post::CompositeReadIO unicode composite io test_read_from_multibyte
rspec ./spec/multipart/post/parts_spec.rb:73 # Multipart::Post::Parts::FilePart test_correct_length
rspec ./spec/multipart/post/parts_spec.rb:77 # Multipart::Post::Parts::FilePart test_multibyte_file_length
rspec ./spec/multipart/post/parts_spec.rb:81 # Multipart::Post::Parts::FilePart test_multibyte_filename
rspec ./spec/multipart/post/parts_spec.rb:88 # Multipart::Post::Parts::FilePart test_force_content_type_header
rspec ./spec/net/http/post/multipart_spec.rb:60 # Net::HTTP::Post::Multipart test_form_multipart_body
rspec ./spec/net/http/post/multipart_spec.rb:67 # Net::HTTP::Post::Multipart test_form_multipart_body_with_stringio
rspec ./spec/net/http/post/multipart_spec.rb:73 # Net::HTTP::Post::Multipart test_form_multiparty_body_with_parts_headers
rspec ./spec/net/http/post/multipart_spec.rb:89 # Net::HTTP::Post::Multipart test_form_multipart_body_with_array_value
rspec ./spec/net/http/post/multipart_spec.rb:106 # Net::HTTP::Post::Multipart test_form_multipart_body_with_arrayparam
rspec ./spec/net/http/post/multipart_spec.rb:117 # Net::HTTP::Put::Multipart test_form_multipart_body_put

```
</details>

- [X] I tested my changes locally.
- [X] I tested my changes in staging.

By mutating inputs, there is more load on downstream consumers of the library. This might require documentation on safely using the library, or `.dup` calls within the library