### PR TITLE
Improve error message

### DIFF
--- a/lib/multipart/post/composite_read_io.rb
+++ b/lib/multipart/post/composite_read_io.rb
@@ -24,7 +24,7 @@ module Multipart
 
       # Read from IOs in order until `length` bytes have been received.
       def read(length = nil, outbuf = nil)
-        raise ArgumentError, "The outbuf parameter must not be frozen" if outbuf.frozen?
+        raise ArgumentError, "The outbuf parameter must not be frozen" if !outbuf.nil? && outbuf.frozen?
         got_result = false
         outbuf = outbuf ? outbuf.replace("") : ""
 

--- a/lib/multipart/post/composite_read_io.rb
+++ b/lib/multipart/post/composite_read_io.rb
@@ -24,6 +24,7 @@ module Multipart
 
       # Read from IOs in order until `length` bytes have been received.
       def read(length = nil, outbuf = nil)
+        raise ArgumentError, "The outbuf parameter must not be frozen" if outbuf.frozen?
         got_result = false
         outbuf = outbuf ? outbuf.replace("") : ""
 


### PR DESCRIPTION
## Description

Changes error message if `outbuf` is frozen.

This will not fix internal changing of outbuf to "" (frozen string), but is for notifying consumers of the library about requirements for the arg (if supplied as non-nil)

### Types of Changes

- Maintenance.

### Testing

- [x] I tested my changes locally.
- [x] I tested my changes in staging.
