### PR TITLE
Error handling frozen outbuf

### DIFF
--- a/lib/multipart/post/composite_read_io.rb
+++ b/lib/multipart/post/composite_read_io.rb
@@ -24,6 +24,7 @@ module Multipart
 
       # Read from IOs in order until `length` bytes have been received.
       def read(length = nil, outbuf = nil)
+        raise ArgumentError, "The outbuf parameter must not be frozen" if !outbuf.nil? && outbuf.frozen?
         got_result = false
         outbuf = outbuf ? outbuf.replace("") : ""
 

--- a/spec/multipart/post/composite_read_io_spec.rb
+++ b/spec/multipart/post/composite_read_io_spec.rb
@@ -114,6 +114,12 @@ module Multipart
         end
       end
 
+      it "test_raises_appropriate_error_if_frozen_outbuf_supplied" do
+        expect do
+          subject.read(nil, 'frozen input'.freeze)
+        end.to raise_error(ArgumentError)
+      end
+
       it "test_convert_error" do
         expect do
           UploadIO.convert!('tmp.txt', 'text/plain', 'tmp.txt', 'tmp.txt')


### PR DESCRIPTION
## Description

Changes error message if `outbuf` is frozen.

This will not fix internal changing of outbuf to "" (frozen string), but is for notifying consumers of the library about requirements for the arg (if supplied as non-nil)

### Types of Changes

- Maintenance.

### Testing

- [x] I tested my changes locally.
- [x] I tested my changes in staging.
