### PR TITLE
Allow mixed key types for parts headers

### DIFF
--- a/lib/multipart/post/multipartable.rb
+++ b/lib/multipart/post/multipartable.rb
@@ -30,8 +30,10 @@ module Multipart
       def initialize(path, params, headers={}, boundary = Multipartable.secure_boundary)
         headers = headers.clone # don't want to modify the original variable
         parts_headers = headers.delete(:parts) || {}
+        parts_headers.transform_keys!(&:to_sym)
+
         super(path, headers)
-        parts = params.map do |k,v|
+        parts = params.transform_keys(&:to_sym).map do |k,v|
           case v
           when Array
             v.map {|item| Parts::Part.new(boundary, k, item, parts_headers[k]) }

--- a/spec/net/http/post/multipart_spec.rb
+++ b/spec/net/http/post/multipart_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Net::HTTP::Post::Multipart do
     assert_additional_headers_added(request, headers[:parts])
   end
 
-  it "test_form_multiparty_body_with_parts_headers_with_mixed_keys" do
+it "can handle multipart form body with mixed header keys" do
     @io = StringIO.new("1234567890")
     @io = Multipart::Post::UploadIO.new @io, "text/plain", TEMP_FILE
     parts = { "text" => 'bar', "file" => @io }


### PR DESCRIPTION
## Description
I ran into this issue when attempting to implement the [Parts Headers example](https://github.com/socketry/multipart-post/#parts-headers)

If the param has a string key, but the key in the headers is a symbol, the additional headers will not be supplied.  In the example in the README the following key is a string:

```
"file_metadata_01" => { "description" => "A nice picture!" }
```

while the header has a symbol for a key:

```
'file_metadata_01': { ... }
``` 

This example does not work with the current code.

### Types of Changes

- Bug fix.

This PR forces the keys to a symbol when retrieving the headers, ensuring a match.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [X] I added tests for my changes.
- [X] I tested my changes locally.
