### PR TITLE
CI: Add Ruby 3.1 to testing matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,6 +17,7 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
         
         experimental: [false]
         env: [""]


### PR DESCRIPTION
## Description

Ruby 3.1 is generally available, so we can have that in the matrix.

### Types of Changes

- Maintenance.
