### PR TITLE
README: Add syntax highlighting to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,15 @@ File.open("./image.jpg") do |file|
   end
 end
 ```
+
 ### Parts Headers
 By default, all individual parts will include the header `Content-Disposition` as well as `Content-Length`, `Content-Transfer-Encoding` and `Content-Type` for the File Parts. 
 
 You may optionally configure the headers `Content-Type` and `Content-ID` for both ParamPart and FilePart by passing in a `parts` header.
 
 For example: 
-```
+
+```ruby
 url = URI.parse('http://www.example.com/upload')
 
 params = {
@@ -115,6 +117,7 @@ headers = {
 
 req = Net::HTTP::Post::Multipart.new(uri, params, headers)
 ```
+
 This would configure the `file_metadata_01` part to include `Content-Type` 
 
 ```
@@ -129,15 +132,16 @@ Content-Type: application/json
 *For FileParts only.*
 
 You can include any number of custom parts headers in addition to `Content-Type` and `Content-ID`. 
-```
+
+```ruby
 headers = {
   'parts': {
     'file_metadata_01': {
       'Content-Type' => "application/json",
       'My-Custom-Header' => "Yo Yo!"
-      }
     }
   }
+}
 ```
 
 


### PR DESCRIPTION
This PR adds more Ruby syntax highlighting to examples in the README.

### Types of Changes

- Maintenance.
