### PR TITLE
Drop Ruby 2.5 or earlier

### DIFF
--- a/multipart-post.gemspec
+++ b/multipart-post.gemspec
@@ -9,7 +9,9 @@ Gem::Specification.new do |spec|
 	spec.summary = "A multipart form post accessory for Net::HTTP."
 	spec.authors = ["Nick Sieger", "Samuel Williams", "Olle Jonsson", "McClain Looney", "Lewis Cowles", "Gustav Ernberg", "Patrick Davey", "Steven Davidovitz", "Alex Koppel", "Ethan Turkeltaub", "Jagtesh Chadha", "Jason York", "Nick", "VincWebwag", "hasimo", "hexfet", "Christine Yen", "David Moles", "Eric Hutzelman", "Feuda Nan", "Gerrit Riessen", "Jan Piotrowski", "Jan-Joost Spanjers", "Jason Moore", "Jeff Hodges", "Johannes Wagener", "Jordi Massaguer Pla", "Lachlan Priest", "Leo Cassarani", "Lonre Wang", "Luke Redpath", "Matt Colyer", "Mislav Marohnić", "Socrates Vicente", "Steffen Grunwald", "Tim Barkley"]
 	spec.license = "MIT"
-	
+
+	spec.required_ruby_version = ">= 2.6.0"
+
 	spec.cert_chain  = ['release.cert']
 	spec.signing_key = File.expand_path('~/.gem/release.pem')
 	


### PR DESCRIPTION
#91 broke dropped support for Ruby 2.0, 2.1, and 2.2 **in the code level** and #75 dropped Ruby 2.0.x, 2.1.x, 2.2.x, 2.3.x, 2.4.x and 2.5.x from **testing**.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)

Closes #92

Follows up #91

### Types of Changes

- Bug fix.
- Breaking change.
- Maintenance.

### Testing

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I tested my changes in staging.
- [x] I tested my changes in production.
