### PR TITLE
Adds Ruby 3.2 to the CI matrix.  Updates checkout actions versions.

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -17,7 +17,7 @@ jobs:
           - "head"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
         
         experimental: [false]
         env: [""]
@@ -38,7 +39,7 @@ jobs:
             experimental: true
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}


### PR DESCRIPTION
Adding Ruby 3.2 to the CI matrix.  Updating checkout actions to v3.

Runs green on my fork.

## Types of Changes

- Maintenance.

## Contribution

- [X] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
