### PR TITLE
Add support for `CompositeReadIO#close`.

### DIFF
--- a/lib/multipart/post/composite_read_io.rb
+++ b/lib/multipart/post/composite_read_io.rb
@@ -33,8 +33,26 @@ module Multipart
         @index = 0
       end
 
+      # Close all the underyling IOs.
+      def close
+        @ios.each do |io|
+          io.close if io.respond_to?(:close)
+        end
+
+        @ios = nil
+        @index = 0
+      end
+
+      def closed?
+        @ios.nil?
+      end
+
       # Read from IOs in order until `length` bytes have been received.
       def read(length = nil, outbuf = nil)
+        if @ios.nil?
+          raise IOError, "CompositeReadIO is closed!"
+        end
+
         got_result = false
         outbuf = outbuf ? outbuf.replace("") : String.new
 

--- a/spec/multipart/post/composite_read_io_spec.rb
+++ b/spec/multipart/post/composite_read_io_spec.rb
@@ -15,6 +15,10 @@ RSpec.shared_context "composite io" do
   it "can close all the ios" do
     subject.close
     expect(subject.closed?).to be_truthy
+    
+    expect do
+      subject.read
+    end.to raise_error(IOError)
   end
   
   it "test_full_read_from_several_ios" do

--- a/spec/multipart/post/composite_read_io_spec.rb
+++ b/spec/multipart/post/composite_read_io_spec.rb
@@ -12,6 +12,11 @@ require 'timeout'
 MULTIBYTE = File.dirname(__FILE__) + '/../../fixtures/multibyte.txt'
 
 RSpec.shared_context "composite io" do
+  it "can close all the ios" do
+    subject.close
+    expect(subject.closed?).to be_truthy
+  end
+  
   it "test_full_read_from_several_ios" do
     expect(subject.read).to be == 'the quick brown fox'
   end


### PR DESCRIPTION
Required to fix <https://github.com/socketry/async-http-faraday/issues/32>.

Faraday's implementation of `#close` expects `CompositeReadIO` to implement close:

```
 0.84s     warn: Async::Task: Writing #<Async::HTTP::Faraday::BodyWrapper:0x0000000128e1ca48> to #<Async::HTTP::Protocol::HTTP2::Response::Stream:0x0000000128a60f08>. [oid=0x2bc] [ec=0x2d0] [pid=37892] [2024-02-07 22:55:46 +1300]
               | Task may have ended with unhandled exception.
               |   NoMethodError: undefined method `close' for an instance of Multipart::Post::CompositeReadIO
               |   → /Users/samuel/.gem/ruby/3.3.0/gems/faraday-multipart-1.0.4/lib/faraday/multipart/file_part.rb:112 in `each'
               |     /Users/samuel/.gem/ruby/3.3.0/gems/faraday-multipart-1.0.4/lib/faraday/multipart/file_part.rb:112 in `close'
               |     lib/async/http/faraday/adapter.rb:30 in `close'
```

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
